### PR TITLE
feat: add severity levels to HandlerError

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@
 ## ✨ Features
 
 - **Custom Error Class**: HandlerError to encapsulate detailed error information, including severity, metadata, and causation.
+- **Flexible Constructor**: Create errors with a message, code, metadata, and cause.
+- **Severity Levels**: Assign severity levels to errors for better handling and logging.
 
 ## 📦 Installation
 
@@ -212,6 +214,31 @@ The HandlerError library supports the following severity levels:
 | warning  | For non-critical issues that don't prevent operation            |
 | info     | For informational messages about error handling                 |
 | debug    | For detailed debugging information                              |
+
+#### Using Severity Levels
+
+The library provides static methods to create errors with specific severity levels. This simplifies error creation and ensures consistency
+
+> **Note:** The severity level is set to `error` by default.
+
+```typescript
+import { HandlerError } from "handler-error";
+
+// Add type information
+const criticalError: HandlerError = HandlerError.critical(
+  "Database connection failed",
+  "DB_001",
+  { attemptCount: 3 },
+  new Error("Connection timeout"),
+);
+
+// Add practical examples for each severity
+const dbError = HandlerError.critical("Database connection failed"); // System cannot function
+const authError = HandlerError.error("Invalid credentials"); // Operation failed
+const rateLimit = HandlerError.warning("Rate limit at 80%"); // Potential issue
+const configLoad = HandlerError.info("Using fallback config"); // Important information
+const queryTime = HandlerError.debug("Query took 1.2s"); // Performance tracking
+```
 
 ### Error Code Conventions
 

--- a/src/handler-error.ts
+++ b/src/handler-error.ts
@@ -43,6 +43,41 @@ export class HandlerError extends Error {
   }
 
   /**
+   * Creates a new `HandlerError` instance with the Critical severity.
+   */
+  public static critical = class CriticalHandlerError extends HandlerError {
+    override readonly severity: Severity = ErrorSeverity.CRITICAL;
+  };
+
+  /**
+   * Creates a new `HandlerError` instance with the Error severity.
+   */
+  public static error = class ErrorHandlerError extends HandlerError {
+    override readonly severity: Severity = ErrorSeverity.ERROR;
+  };
+
+  /**
+   * Creates a new `HandlerError` instance with the Warning severity.
+   */
+  public static warning = class WarningHandlerError extends HandlerError {
+    override readonly severity: Severity = ErrorSeverity.WARNING;
+  };
+
+  /**
+   * Creates a new `HandlerError` instance with the Info severity.
+   */
+  public static info = class InfoHandlerError extends HandlerError {
+    override readonly severity: Severity = ErrorSeverity.INFO;
+  };
+
+  /**
+   * Creates a new `HandlerError` instance with the Debug severity.
+   */
+  public static debug = class DebugHandlerError extends HandlerError {
+    override readonly severity: Severity = ErrorSeverity.DEBUG;
+  };
+
+  /**
    * Serializes the error into a plain object.
    *
    * @returns An object representing the serialized error.

--- a/test/handler-error.test.ts
+++ b/test/handler-error.test.ts
@@ -130,40 +130,82 @@ describe("HandlerError", () => {
     });
   });
 
-  describe("convertToHandlerError", () => {
-    it("should handle standard error as cause", () => {
+  describe("severity", () => {
+    it("should create an error with the specified severity", () => {
       // Arrange
-      const cause = new Error("Test cause");
-
-      // Act
-      const error = new HandlerError("Test error", cause);
+      const errorCritical = new HandlerError.critical("Test critical error");
+      const errorError = new HandlerError.error("Test error error");
+      const errorWarning = new HandlerError.warning("Test warning error");
+      const errorInfo = new HandlerError.info("Test info error");
+      const errorDebug = new HandlerError.debug("Test debug error");
 
       // Assert
-      expect(error.cause).toBeInstanceOf(HandlerError);
-      expect(error.cause?.message).toBe("Test cause");
+      expect(errorCritical.severity).toBe(ErrorSeverity.CRITICAL);
+      expect(errorError.severity).toBe(ErrorSeverity.ERROR);
+      expect(errorWarning.severity).toBe(ErrorSeverity.WARNING);
+      expect(errorInfo.severity).toBe(ErrorSeverity.INFO);
+      expect(errorDebug.severity).toBe(ErrorSeverity.DEBUG);
     });
 
-    it("should handle HandlerError as cause", () => {
+    it("should create an error with the specified severity and metadata", () => {
       // Arrange
-      const cause = new HandlerError("Test cause");
+      const metadata = { key: "value" };
 
       // Act
-      const error = new HandlerError("Test error", cause);
+      const errorCritical = new HandlerError.critical("Test critical error", metadata);
 
       // Assert
-      expect(error.cause).toBeInstanceOf(HandlerError);
-      expect(error.cause?.message).toBe("Test cause");
+      expect(errorCritical.severity).toBe(ErrorSeverity.CRITICAL);
+      expect(errorCritical.metadata).toBe(metadata);
     });
 
-    it("should not set the cause if not is a Error", () => {
+    it("should create an error with the specified severity, metadata and error", () => {
       // Arrange
-      const cause = "Test cause" as unknown as Error;
+      const metadata = { key: "value" };
+      const rootError = new Error("Root error");
 
       // Act
-      const error = new HandlerError("Test error", cause);
+      const errorCritical = new HandlerError.critical("Test critical error", metadata, rootError);
 
       // Assert
-      expect(error.cause).toBeUndefined();
+      expect(errorCritical.severity).toBe(ErrorSeverity.CRITICAL);
+      expect(errorCritical.metadata).toBe(metadata);
+      expect(errorCritical.cause).toBeInstanceOf(HandlerError);
+      expect(errorCritical.cause?.message).toBe("Root error");
+    });
+
+    it("should create an error with the specified severity, metadata and code", () => {
+      // Arrange
+      const metadata = { key: "value" };
+
+      // Act
+      const errorCritical = new HandlerError.critical("Test critical error", "VAL001", metadata);
+
+      // Assert
+      expect(errorCritical.severity).toBe(ErrorSeverity.CRITICAL);
+      expect(errorCritical.code).toBe("VAL001");
+      expect(errorCritical.metadata).toBe(metadata);
+    });
+
+    it("should create an error with the specified severity, metadata, code and error", () => {
+      // Arrange
+      const metadata = { key: "value" };
+      const rootError = new Error("Root error");
+
+      // Act
+      const errorCritical = new HandlerError.critical(
+        "Test critical error",
+        "VAL001",
+        metadata,
+        rootError,
+      );
+
+      // Assert
+      expect(errorCritical.severity).toBe(ErrorSeverity.CRITICAL);
+      expect(errorCritical.code).toBe("VAL001");
+      expect(errorCritical.metadata).toBe(metadata);
+      expect(errorCritical.cause).toBeInstanceOf(HandlerError);
+      expect(errorCritical.cause?.message).toBe("Root error");
     });
   });
 


### PR DESCRIPTION
# Pull Request

## Description

<!-- Brief description of the changes made. -->

---

## Checklist

### Code and functionality

- [x] ✔️ I have checked the new functionality and working as expected.
- [x] 🧹 I have cleaned the code and deleted unnecessary comments or logs.
- [x] 🧪 I have added tests to cover my changes

### Documentation

- [x] 📘 I have updated the README.
- [ ] ✍️ I have updated the documentation accordingly.
- [x] 📚 I have updated the examples in the documentation.
- [ ] 🌐 I have updated the project website.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added flexible constructor for error creation.
  - Introduced severity levels for errors (critical, error, warning, info, debug).
  - Implemented static methods for creating errors with specific severity levels.

- **Documentation**
  - Updated README with detailed information on new error handling capabilities.
  - Added a new section on using severity levels in error creation with practical examples.

- **Tests**
  - Enhanced test suite to validate new severity-based error creation.
  - Improved test coverage for error constructor and severity handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->